### PR TITLE
Only test core for the moment

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ requirements:
 
 test:
   commands:
-    - julia -e 'Base.runtests("LibGit2/online Pkg/pkg")'
+    - julia -e 'Base.runtests(["core"])'
   requires:
     - perl
 


### PR DESCRIPTION
The tests for LibGit2 and Pkg are acting a bit strangely in the conda/Docker environment. Let's just test the core to start:

```
Test  (Worker) | Time (s) | GC (s) | GC % | Alloc (MB) | RSS (MB)
core       (1) |        started at 2021-07-28T01:48:01.195
core       (1) |    87.89 |   9.50 | 10.8 |   13407.23 |  2129.93

Test Summary: |    Pass  Broken    Total
  Overall     | 8445873       4  8445877
    SUCCESS
+ exit 0

Resource usage statistics from testing julia:
   Process count: 4
   CPU time: Sys=0:00:03.7, User=0:01:30.7
   Memory: 2.2G
   Disk usage: 20B
   Time elapsed: 0:01:36.4
```